### PR TITLE
upgrade ocm version

### DIFF
--- a/osd-aws/install.sh
+++ b/osd-aws/install.sh
@@ -26,7 +26,7 @@ if [[ "$OS" == "darwin" ]]; then
     fi
 
     if [ -z "$(which ocm)" ]; then
-        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.54/ocm-$OS-amd64
+        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.63/ocm-$OS-amd64
         chmod +x /usr/local/bin/ocm
         printf "${GREEN}ocm version `ocm version` installed${CLEAR}\n"
     else
@@ -47,7 +47,7 @@ else
     fi
 
     if [ -z "$(which ocm)" ]; then
-        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.54/ocm-$OS-amd64
+        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.63/ocm-$OS-amd64
         chmod +x /usr/local/bin/ocm
         printf "${GREEN}ocm version `ocm version` installed${CLEAR}\n"
     else

--- a/osd-gcp/install.sh
+++ b/osd-gcp/install.sh
@@ -26,7 +26,7 @@ if [[ "$OS" == "darwin" ]]; then
     fi
 
     if [ -z "$(which ocm)" ]; then
-        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.54/ocm-$OS-amd64
+        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.63/ocm-$OS-amd64
         chmod +x /usr/local/bin/ocm
         printf "${GREEN}ocm version `ocm version` installed${CLEAR}\n"
     else
@@ -47,7 +47,7 @@ else
     fi
 
     if [ -z "$(which ocm)" ]; then
-        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.54/ocm-$OS-amd64
+        curl -Lo /usr/local/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.63/ocm-$OS-amd64
         chmod +x /usr/local/bin/ocm
         printf "${GREEN}ocm version `ocm version` installed${CLEAR}\n"
     else


### PR DESCRIPTION
Signed-off-by: hchenxa <huichen@redhat.com>


with the default version in install.sh, the login failed like below:
```
root@hchenxa:~/github/bootstrap-ks/osd-aws# ./install.sh
Unable to connect to the server: dial tcp 34.74.187.63:443: i/o timeout
kubectl version Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.1-5-g76a04fc", GitCommit:"e29b355e74c9efd4491d64b9bb013c6091770d20", GitTreeState:"clean", BuildDate:"2021-06-03T23:21:41Z", GoVersion:"go1.15.7", Compiler:"gc", Platform:"linux/amd64"} already installed
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 22.9M  100 22.9M    0     0  48.5M      0 --:--:-- --:--:-- --:--:-- 48.5M
ocm version 0.1.54 installed
root@hchenxa:~/github/bootstrap-ks/osd-aws# ./provision.sh
Using hchen-osd-cc to identify all created resources.
E0614 11:11:24.669921   11478 transport_wrapper.go:620] Can't get tokens, got HTTP code 200, will not retry: expected 'bearer' token type but got 'Bearer
Error: Can't get token: expected 'bearer' token type but got 'Bearer

```

after upgrade the ocm version to `v0.1.63`, the issue was gone.
```
