### PR TITLE
add wait for ROSA api address ready

### DIFF
--- a/rosa/provision.sh
+++ b/rosa/provision.sh
@@ -156,8 +156,22 @@ ${ROSA} create cluster \
     --yes
 printf "${CLEAR}"
 
-
 #-----EXTRACT DETAILS-----#
+# The API url may not ready in the cluster info , need a for loop here to wait for the API URL ready
+TIMEOUT=${TIMEOUT:-"600"}
+printf "${BLUE}Polling for $TIMEOUT seconds for the ${RESOURCE_NAME} cluster to be ready.${CLEAR}\n"
+acc=0
+while ! (${ROSA} describe cluster --cluster=${RESOURCE_NAME} -o json | jq -er .api.url)
+do
+    printf "${YELLOW}Waiting for cluster ${RESOURCE_NAME} API address ready...${CLEAR}\n"
+    sleep 5
+    acc=$((acc+5))
+    if [ "$acc" -ge "$TIMEOUT" ]; then
+        printf "${RED} The cluster ${RESOURCE_NAME} API was not ready in $TIMEOUT seconds, exits."
+        exit 1
+    fi
+done
+
 api_url=$(${ROSA} describe cluster --cluster=${RESOURCE_NAME} | grep "API URL:" | sed -n "s/API URL:[ ]*\(.*\)/\1/p")
 console_url=$(${ROSA} describe cluster --cluster=${RESOURCE_NAME} | grep "Console URL:" | sed -n "s/Console URL:[ ]*\(.*\)/\1/p")
 # Update account ID logged earlier to match that of the cluster (just in case)


### PR DESCRIPTION
Signed-off-by: hchenxa <huichen@redhat.com>

we found sometimes the API url was null after the cluster provision success:
```
time="2022-08-20T18:27:25Z" level=info msg="Waiting up to 40m0s (until 7:07PM) for the cluster at https://api.clc-rosa-43.w8f6.p1.openshiftapps.com:6443/ to initialize..."
time="2022-08-20T18:27:25Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.11.0: 773 of 802 done (96% complete)"
time="2022-08-20T18:29:51Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.11.0: 773 of 802 done (96% complete)"
time="2022-08-20T18:30:07Z" level=debug msg="Still waiting for the cluster to initialize: Some cluster operators are still updating: authentication, console, insights, kube-apiserver"
time="2022-08-20T18:30:52Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.11.0: 796 of 802 done (99% complete)"
INFO: Cluster 'clc-rosa-43' is now ready
Creating an admin user on clc-rosa-43.
ROSA cluster named clc-rosa-43 provisioned successfully.
Console URL: 
API URL: 
Username: cluster-admin
Password: *****
Full Password and username can be found in /home/centos/workspace/qe-acm-automation-poc/create_rosa_cluster/rosa/clc-rosa-43.json
To destroy this cluster run './destroy.sh /home/centos/workspace/qe-acm-automation-poc/create_rosa_cluster/rosa/clc-rosa-43.json'
+ tar -zx
+ curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 20 50.1M   20 10.0M    0     0  30.9M      0  0:00:01 --:--:--  0:00:01 30.8M
100 50.1M  100 50.1M    0     0  45.0M      0  0:00:01  0:00:01 --:--:-- 45.0M
+ cp oc /usr/local/bin/
+ touch clc-rosa-43-rosa.kubeconfig
+ set +e
++ seq 1 300
+ for i in `seq 1 300`
++ cat clc-rosa-43.json
++ jq -r .USERNAME
++ cat clc-rosa-43.json
++ jq -r .PASSWORD
++ jq -r .API_URL
++ cat clc-rosa-43.json
+ KUBECONFIG=./clc-rosa-43-rosa.kubeconfig
+ oc login --insecure-skip-tls-verify -u cluster-admin -p BBvYn-t8FMi-ERBYC-SMVNh
error: A server URL must be specified
```
so, I was trying to add a wait here to wait the API address appear in the cluster info.